### PR TITLE
feat: Implement flexible app monitoring with add/remove functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+# lib/  # Commented out to allow Flutter's lib/ directory
 lib64/
 parts/
 sdist/

--- a/frontend/ios/Flutter/Debug.xcconfig
+++ b/frontend/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/frontend/ios/Flutter/Release.xcconfig
+++ b/frontend/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/frontend/ios/Podfile
+++ b/frontend/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Flutter (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		77B679E888B1E729651766F1 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B3D04857880F8455330AECD /* Pods_Runner.framework */; };
+		92FCE2562D903A1BC08210CD /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FAD64B7B3E8C44C912934E75 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -42,9 +44,13 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1B3D04857880F8455330AECD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D243F763B0F732973FF609F /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		2DE0D2B31A472AE1DEDA8E91 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		4A196B02D9056AAFF0C91047 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -55,19 +61,41 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B45BF759D79FB5E76D6F9C3C /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		BEE55401CC41D1B76ABAB490 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FAD64B7B3E8C44C912934E75 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FC87E6535E7AB887E49F23FF /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		872E8ABE2547D41915083A3F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				92FCE2562D903A1BC08210CD /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				77B679E888B1E729651766F1 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0D167A9C67D441AA783E181F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1B3D04857880F8455330AECD /* Pods_Runner.framework */,
+				FAD64B7B3E8C44C912934E75 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +122,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				D657A750E2EBA6DA7B55250B /* Pods */,
+				0D167A9C67D441AA783E181F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +151,20 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		D657A750E2EBA6DA7B55250B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4A196B02D9056AAFF0C91047 /* Pods-Runner.debug.xcconfig */,
+				B45BF759D79FB5E76D6F9C3C /* Pods-Runner.release.xcconfig */,
+				FC87E6535E7AB887E49F23FF /* Pods-Runner.profile.xcconfig */,
+				BEE55401CC41D1B76ABAB490 /* Pods-RunnerTests.debug.xcconfig */,
+				2DE0D2B31A472AE1DEDA8E91 /* Pods-RunnerTests.release.xcconfig */,
+				2D243F763B0F732973FF609F /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				C21FE934D3EA42E0F1F5B0C2 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				872E8ABE2547D41915083A3F /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				5FD16E21C8FA9F2B95606042 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				4B2FA0624F82DBCDD880EA12 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -238,6 +286,45 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		4B2FA0624F82DBCDD880EA12 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5FD16E21C8FA9F2B95606042 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +339,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C21FE934D3EA42E0F1F5B0C2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -378,6 +487,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = BEE55401CC41D1B76ABAB490 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +505,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2DE0D2B31A472AE1DEDA8E91 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +521,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2D243F763B0F732973FF609F /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'ui/splash_screen.dart';
+
+void main() {
+  runApp(const MiivvyApp());
+}
+
+class MiivvyApp extends StatelessWidget {
+  const MiivvyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Miivvy',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.light,
+        ),
+        useMaterial3: true,
+      ),
+      home: const SplashScreen(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}

--- a/frontend/lib/models/monitored_app.dart
+++ b/frontend/lib/models/monitored_app.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+/// 監視対象アプリのデータモデル
+class MonitoredApp {
+  final String id;
+  final String name;
+  final String displayName;
+  final IconData icon;
+  final Color color;
+  bool isEnabled;
+
+  MonitoredApp({
+    required this.id,
+    required this.name,
+    required this.displayName,
+    required this.icon,
+    required this.color,
+    this.isEnabled = false,
+  });
+
+  /// JSONからMonitoredAppを生成
+  factory MonitoredApp.fromJson(Map<String, dynamic> json) {
+    return MonitoredApp(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      displayName: json['displayName'] as String,
+      icon: _getIconFromName(json['name'] as String),
+      color: Color(json['color'] as int),
+      isEnabled: json['isEnabled'] as bool? ?? false,
+    );
+  }
+
+  /// MonitoredAppをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'displayName': displayName,
+      'color': color.value,
+      'isEnabled': isEnabled,
+    };
+  }
+
+  /// アプリ名からアイコンを取得
+  static IconData _getIconFromName(String name) {
+    switch (name.toLowerCase()) {
+      case 'line':
+        return Icons.chat_bubble;
+      case 'instagram':
+        return Icons.photo_camera;
+      case 'x':
+      case 'twitter':
+        return Icons.tag;
+      case 'facebook':
+        return Icons.facebook;
+      default:
+        return Icons.apps;
+    }
+  }
+
+  /// デフォルトの監視対象アプリリスト（初期状態は空）
+  static List<MonitoredApp> getDefaultApps() {
+    return [];
+  }
+
+  /// 追加可能なアプリのマスターリスト
+  static List<MonitoredApp> getAvailableApps() {
+    return [
+      MonitoredApp(
+        id: 'line',
+        name: 'LINE',
+        displayName: 'LINE',
+        icon: Icons.chat_bubble,
+        color: const Color(0xFF00B900),
+        isEnabled: false,
+      ),
+      MonitoredApp(
+        id: 'instagram',
+        name: 'Instagram',
+        displayName: 'Instagram',
+        icon: Icons.photo_camera,
+        color: const Color(0xFFE4405F),
+        isEnabled: false,
+      ),
+      MonitoredApp(
+        id: 'x',
+        name: 'X',
+        displayName: 'X (Twitter)',
+        icon: Icons.tag,
+        color: const Color(0xFF000000),
+        isEnabled: false,
+      ),
+      MonitoredApp(
+        id: 'facebook',
+        name: 'Facebook',
+        displayName: 'Facebook',
+        icon: Icons.facebook,
+        color: const Color(0xFF1877F2),
+        isEnabled: false,
+      ),
+      MonitoredApp(
+        id: 'tiktok',
+        name: 'TikTok',
+        displayName: 'TikTok',
+        icon: Icons.music_note,
+        color: const Color(0xFF000000),
+        isEnabled: false,
+      ),
+      MonitoredApp(
+        id: 'discord',
+        name: 'Discord',
+        displayName: 'Discord',
+        icon: Icons.chat,
+        color: const Color(0xFF5865F2),
+        isEnabled: false,
+      ),
+    ];
+  }
+
+  MonitoredApp copyWith({
+    String? id,
+    String? name,
+    String? displayName,
+    IconData? icon,
+    Color? color,
+    bool? isEnabled,
+  }) {
+    return MonitoredApp(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      displayName: displayName ?? this.displayName,
+      icon: icon ?? this.icon,
+      color: color ?? this.color,
+      isEnabled: isEnabled ?? this.isEnabled,
+    );
+  }
+}

--- a/frontend/lib/services/preferences_service.dart
+++ b/frontend/lib/services/preferences_service.dart
@@ -1,0 +1,132 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/monitored_app.dart';
+
+/// アプリ設定を永続化するサービス
+class PreferencesService {
+  static const String _keyMonitoredApps = 'monitored_apps';
+  static const String _keyIsMonitoring = 'is_monitoring';
+
+  static PreferencesService? _instance;
+  static SharedPreferences? _prefs;
+
+  PreferencesService._();
+
+  /// シングルトンインスタンスを取得
+  static Future<PreferencesService> getInstance() async {
+    if (_instance == null) {
+      _instance = PreferencesService._();
+      _prefs = await SharedPreferences.getInstance();
+    }
+    return _instance!;
+  }
+
+  /// 監視対象アプリのリストを保存
+  Future<bool> saveMonitoredApps(List<MonitoredApp> apps) async {
+    try {
+      final jsonList = apps.map((app) => app.toJson()).toList();
+      final jsonString = jsonEncode(jsonList);
+      return await _prefs!.setString(_keyMonitoredApps, jsonString);
+    } catch (e) {
+      print('Error saving monitored apps: $e');
+      return false;
+    }
+  }
+
+  /// 監視対象アプリのリストを取得
+  Future<List<MonitoredApp>> getMonitoredApps() async {
+    try {
+      final jsonString = _prefs!.getString(_keyMonitoredApps);
+
+      if (jsonString == null) {
+        // 初回起動時はデフォルトのアプリリストを返す
+        final defaultApps = MonitoredApp.getDefaultApps();
+        await saveMonitoredApps(defaultApps);
+        return defaultApps;
+      }
+
+      final jsonList = jsonDecode(jsonString) as List;
+      return jsonList.map((json) => MonitoredApp.fromJson(json)).toList();
+    } catch (e) {
+      print('Error loading monitored apps: $e');
+      return MonitoredApp.getDefaultApps();
+    }
+  }
+
+  /// 特定のアプリの有効/無効を切り替え
+  Future<bool> toggleApp(String appId, bool isEnabled) async {
+    try {
+      final apps = await getMonitoredApps();
+      final index = apps.indexWhere((app) => app.id == appId);
+
+      if (index != -1) {
+        apps[index].isEnabled = isEnabled;
+        return await saveMonitoredApps(apps);
+      }
+
+      return false;
+    } catch (e) {
+      print('Error toggling app: $e');
+      return false;
+    }
+  }
+
+  /// 監視機能の全体ON/OFFを保存
+  Future<bool> setMonitoring(bool isMonitoring) async {
+    return await _prefs!.setBool(_keyIsMonitoring, isMonitoring);
+  }
+
+  /// 監視機能の全体ON/OFFを取得
+  bool getIsMonitoring() {
+    return _prefs!.getBool(_keyIsMonitoring) ?? false;
+  }
+
+  /// 有効になっているアプリの数を取得
+  Future<int> getEnabledAppsCount() async {
+    final apps = await getMonitoredApps();
+    return apps.where((app) => app.isEnabled).length;
+  }
+
+  /// アプリをみまもりリストに追加
+  Future<bool> addApp(MonitoredApp app) async {
+    try {
+      final apps = await getMonitoredApps();
+
+      // すでに追加されているかチェック
+      if (apps.any((a) => a.id == app.id)) {
+        print('App already exists: ${app.id}');
+        return false;
+      }
+
+      apps.add(app);
+      return await saveMonitoredApps(apps);
+    } catch (e) {
+      print('Error adding app: $e');
+      return false;
+    }
+  }
+
+  /// アプリをみまもりリストから削除
+  Future<bool> removeApp(String appId) async {
+    try {
+      final apps = await getMonitoredApps();
+      apps.removeWhere((app) => app.id == appId);
+      return await saveMonitoredApps(apps);
+    } catch (e) {
+      print('Error removing app: $e');
+      return false;
+    }
+  }
+
+  /// すべての設定をクリア
+  Future<bool> clearAll() async {
+    try {
+      await _prefs!.remove(_keyMonitoredApps);
+      await _prefs!.remove(_keyIsMonitoring);
+      return true;
+    } catch (e) {
+      print('Error clearing preferences: $e');
+      return false;
+    }
+  }
+}

--- a/frontend/lib/ui/add_app_screen.dart
+++ b/frontend/lib/ui/add_app_screen.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import '../models/monitored_app.dart';
+import '../services/preferences_service.dart';
+import 'shortcut_guide_screen.dart';
+
+class AddAppScreen extends StatefulWidget {
+  final List<MonitoredApp> currentApps;
+
+  const AddAppScreen({
+    super.key,
+    required this.currentApps,
+  });
+
+  @override
+  State<AddAppScreen> createState() => _AddAppScreenState();
+}
+
+class _AddAppScreenState extends State<AddAppScreen> {
+  List<MonitoredApp> _availableApps = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAvailableApps();
+  }
+
+  void _loadAvailableApps() {
+    // すでに追加されているアプリを除外
+    final allApps = MonitoredApp.getAvailableApps();
+    final currentAppIds = widget.currentApps.map((app) => app.id).toSet();
+
+    setState(() {
+      _availableApps = allApps.where((app) => !currentAppIds.contains(app.id)).toList();
+    });
+  }
+
+  Future<void> _onAppSelected(MonitoredApp app) async {
+    // 許可確認ダイアログを表示
+    final confirmed = await _showPermissionDialog(app);
+
+    if (confirmed == true) {
+      // アプリを追加
+      final prefs = await PreferencesService.getInstance();
+      final success = await prefs.addApp(app);
+
+      if (success && mounted) {
+        // ショートカット設定ガイドを表示
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => ShortcutGuideScreen(app: app),
+          ),
+        );
+
+        // 画面を閉じる
+        if (mounted) {
+          Navigator.pop(context, true);
+        }
+      }
+    }
+  }
+
+  Future<bool?> _showPermissionDialog(MonitoredApp app) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: app.color.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                app.icon,
+                color: app.color,
+                size: 24,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                '${app.displayName}を追加',
+                style: const TextStyle(fontSize: 18),
+              ),
+            ),
+          ],
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'このアプリをみまもり対象に追加しますか？',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _buildPermissionItem(
+              icon: Icons.history,
+              title: '使用履歴を記録',
+              description: 'このアプリの起動や使用時刻を記録します',
+            ),
+            const SizedBox(height: 12),
+            _buildPermissionItem(
+              icon: Icons.settings_applications,
+              title: 'ショートカット設定',
+              description: '次の画面で設定方法をご案内します',
+            ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.blue.shade50,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.blue.shade200),
+              ),
+              child: Row(
+                children: [
+                  Icon(Icons.info_outline, color: Colors.blue.shade700, size: 20),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      '追加後はON/OFFで切り替えできます',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Colors.blue.shade700,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: app.color,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('追加する'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPermissionItem({
+    required IconData icon,
+    required String title,
+    required String description,
+  }) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(icon, color: Colors.deepPurple, size: 20),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                description,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey[600],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        title: const Text(
+          'アプリを追加',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        backgroundColor: Colors.deepPurple,
+        foregroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: _availableApps.isEmpty
+          ? _buildEmptyState()
+          : ListView.builder(
+              padding: const EdgeInsets.all(20.0),
+              itemCount: _availableApps.length,
+              itemBuilder: (context, index) {
+                final app = _availableApps[index];
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12.0),
+                  child: _buildAppCard(app),
+                );
+              },
+            ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.check_circle_outline,
+            size: 80,
+            color: Colors.grey[300],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'すべてのアプリを追加済みです',
+            style: TextStyle(
+              fontSize: 16,
+              color: Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAppCard(MonitoredApp app) {
+    return InkWell(
+      onTap: () => _onAppSelected(app),
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.grey.shade200, width: 2),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            // アプリアイコン
+            Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: app.color.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Icon(
+                app.icon,
+                color: app.color,
+                size: 32,
+              ),
+            ),
+            const SizedBox(width: 16),
+
+            // アプリ名
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    app.displayName,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'タップして追加',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // 追加アイコン
+            Icon(
+              Icons.add_circle_outline,
+              color: app.color,
+              size: 28,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/dashboard_screen.dart
+++ b/frontend/lib/ui/dashboard_screen.dart
@@ -1,0 +1,601 @@
+import 'package:flutter/material.dart';
+import '../models/monitored_app.dart';
+import '../services/preferences_service.dart';
+import 'settings_screen.dart';
+import 'add_app_screen.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  bool _isMonitoring = false;
+  List<MonitoredApp> _monitoredApps = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await PreferencesService.getInstance();
+    final apps = await prefs.getMonitoredApps();
+    final isMonitoring = prefs.getIsMonitoring();
+
+    setState(() {
+      _monitoredApps = apps;
+      _isMonitoring = isMonitoring;
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _toggleMonitoring() async {
+    final newState = !_isMonitoring;
+    final prefs = await PreferencesService.getInstance();
+    await prefs.setMonitoring(newState);
+
+    setState(() {
+      _isMonitoring = newState;
+    });
+  }
+
+  Future<void> _toggleApp(String appId, bool isEnabled) async {
+    final prefs = await PreferencesService.getInstance();
+    await prefs.toggleApp(appId, isEnabled);
+
+    setState(() {
+      final index = _monitoredApps.indexWhere((app) => app.id == appId);
+      if (index != -1) {
+        _monitoredApps[index].isEnabled = isEnabled;
+      }
+    });
+  }
+
+  Future<void> _navigateToAddApp() async {
+    final result = await Navigator.push<bool>(
+      context,
+      MaterialPageRoute(
+        builder: (context) => AddAppScreen(currentApps: _monitoredApps),
+      ),
+    );
+
+    // アプリが追加された場合はデータを再読み込み
+    if (result == true) {
+      _loadData();
+    }
+  }
+
+  Future<void> _removeApp(MonitoredApp app) async {
+    // 確認ダイアログ
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('${app.displayName}を削除'),
+        content: const Text('このアプリをみまもり一覧から削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      final prefs = await PreferencesService.getInstance();
+      await prefs.removeApp(app.id);
+      _loadData();
+    }
+  }
+
+  int get _enabledAppsCount {
+    return _monitoredApps.where((app) => app.isEnabled).length;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        title: const Text(
+          'Miivvy',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            letterSpacing: 1.5,
+          ),
+        ),
+        centerTitle: true,
+        backgroundColor: Colors.deepPurple,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings_outlined),
+            onPressed: () async {
+              await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const SettingsScreen()),
+              );
+              // 設定画面から戻ってきたらデータを再読み込み
+              _loadData();
+            },
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 監視ステータスカード
+              _buildStatusCard(),
+              const SizedBox(height: 24),
+
+              // 監視対象アプリ一覧
+              _buildMonitoredAppsSection(),
+              const SizedBox(height: 24),
+
+              // 今日のサマリー
+              _buildSummarySection(),
+              const SizedBox(height: 24),
+
+              // 最近のアクティビティ
+              _buildRecentActivitySection(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusCard() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(24.0),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: _isMonitoring
+              ? [Colors.green.shade400, Colors.green.shade600]
+              : [Colors.grey.shade400, Colors.grey.shade600],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: (_isMonitoring ? Colors.green : Colors.grey).withOpacity(0.3),
+            blurRadius: 15,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Icon(
+            _isMonitoring ? Icons.visibility : Icons.visibility_off,
+            size: 64,
+            color: Colors.white,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            _isMonitoring ? 'みまもり中' : '休憩中',
+            style: const TextStyle(
+              fontSize: 28,
+              fontWeight: FontWeight.bold,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            _isMonitoring
+                ? 'アプリの使用を記録しています'
+                : 'タップしてみまもりを始める',
+            style: const TextStyle(
+              fontSize: 14,
+              color: Colors.white70,
+            ),
+          ),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            height: 50,
+            child: ElevatedButton(
+              onPressed: _toggleMonitoring,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.white,
+                foregroundColor: _isMonitoring ? Colors.green : Colors.grey,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                elevation: 0,
+              ),
+              child: Text(
+                _isMonitoring ? 'みまもりを止める' : 'みまもりを始める',
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummarySection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '今日のサマリー',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Row(
+          children: [
+            Expanded(
+              child: _buildSummaryCard(
+                icon: Icons.apps,
+                title: 'みまもり中のアプリ',
+                value: '$_enabledAppsCount',
+                color: Colors.blue,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _buildSummaryCard(
+                icon: Icons.notifications_active,
+                title: '検知イベント',
+                value: '0',
+                color: Colors.orange,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryCard({
+    required IconData icon,
+    required String title,
+    required String value,
+    required Color color,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(20.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: color, size: 32),
+          const SizedBox(height: 12),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 32,
+              fontWeight: FontWeight.bold,
+              color: Colors.grey[800],
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            title,
+            style: TextStyle(
+              fontSize: 12,
+              color: Colors.grey[600],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRecentActivitySection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '最近のアクティビティ',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Container(
+          padding: const EdgeInsets.all(40.0),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.05),
+                blurRadius: 10,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Center(
+            child: Column(
+              children: [
+                Icon(
+                  Icons.inbox_outlined,
+                  size: 64,
+                  color: Colors.grey[300],
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'まだアクティビティがありません',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Colors.grey[600],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '監視を開始すると、ここに履歴が表示されます',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.grey[500],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMonitoredAppsSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const Text(
+              'みまもり一覧',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            TextButton.icon(
+              onPressed: _navigateToAddApp,
+              icon: const Icon(Icons.add_circle_outline, size: 20),
+              label: const Text('追加'),
+              style: TextButton.styleFrom(
+                foregroundColor: Colors.deepPurple,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        if (_monitoredApps.isEmpty)
+          _buildEmptyAppsState()
+        else
+          ..._monitoredApps.map((app) => Padding(
+            padding: const EdgeInsets.only(bottom: 12.0),
+            child: _buildAppCard(app),
+          )),
+      ],
+    );
+  }
+
+  Widget _buildEmptyAppsState() {
+    return Container(
+      padding: const EdgeInsets.all(40.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.grey.shade200, width: 2),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Center(
+        child: Column(
+          children: [
+            Icon(
+              Icons.apps_outlined,
+              size: 64,
+              color: Colors.grey[300],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'まだアプリが追加されていません',
+              style: TextStyle(
+                fontSize: 16,
+                color: Colors.grey[600],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '右上の「追加」ボタンからアプリを追加してください',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 12,
+                color: Colors.grey[500],
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: _navigateToAddApp,
+              icon: const Icon(Icons.add),
+              label: const Text('アプリを追加'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.deepPurple,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAppCard(MonitoredApp app) {
+    return Dismissible(
+      key: Key(app.id),
+      background: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        decoration: BoxDecoration(
+          color: Colors.red,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        alignment: Alignment.centerRight,
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            Icon(Icons.delete_outline, color: Colors.white, size: 28),
+            SizedBox(width: 8),
+            Text(
+              '削除',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+      direction: DismissDirection.endToStart,
+      confirmDismiss: (direction) async {
+        return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: Text('${app.displayName}を削除'),
+            content: const Text('このアプリをみまもり一覧から削除しますか？'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('キャンセル'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                style: TextButton.styleFrom(foregroundColor: Colors.red),
+                child: const Text('削除'),
+              ),
+            ],
+          ),
+        );
+      },
+      onDismissed: (direction) async {
+        final prefs = await PreferencesService.getInstance();
+        await prefs.removeApp(app.id);
+        _loadData();
+      },
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: app.isEnabled ? app.color.withOpacity(0.3) : Colors.grey.shade200,
+            width: 2,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            // アプリアイコン
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: app.color.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(
+                app.icon,
+                color: app.color,
+                size: 28,
+              ),
+            ),
+            const SizedBox(width: 16),
+
+            // アプリ名
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    app.displayName,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    app.isEnabled ? 'みまもりON' : 'みまもりOFF',
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: app.isEnabled ? app.color : Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // ON/OFFスイッチ
+            Switch(
+              value: app.isEnabled,
+              onChanged: (value) => _toggleApp(app.id, value),
+              activeColor: app.color,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/settings_screen.dart
+++ b/frontend/lib/ui/settings_screen.dart
@@ -1,0 +1,295 @@
+import 'package:flutter/material.dart';
+import '../services/preferences_service.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  int _enabledAppsCount = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await PreferencesService.getInstance();
+    final count = await prefs.getEnabledAppsCount();
+
+    setState(() {
+      _enabledAppsCount = count;
+    });
+  }
+
+  Future<void> _clearAllData() async {
+    // 確認ダイアログを表示
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('確認'),
+        content: const Text('すべてのログと設定をクリアしますか？\nこの操作は取り消せません。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('クリア'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      final prefs = await PreferencesService.getInstance();
+      await prefs.clearAll();
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('すべてのデータをクリアしました'),
+            backgroundColor: Colors.green,
+          ),
+        );
+
+        // データを再読み込み
+        _loadData();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        title: const Text(
+          '設定',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        backgroundColor: Colors.deepPurple,
+        foregroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // データ管理セクション
+              _buildSectionHeader('データ管理'),
+              const SizedBox(height: 16),
+              _buildSettingCard(
+                icon: Icons.delete_sweep,
+                title: 'すべてのログをクリア',
+                subtitle: 'アプリ設定と記録されたログをすべて削除します',
+                color: Colors.red,
+                onTap: _clearAllData,
+              ),
+              const SizedBox(height: 32),
+
+              // アプリ情報セクション
+              _buildSectionHeader('アプリ情報'),
+              const SizedBox(height: 16),
+              _buildInfoCard(
+                icon: Icons.info_outline,
+                title: 'バージョン',
+                value: '1.0.0',
+                color: Colors.blue,
+              ),
+              const SizedBox(height: 12),
+              _buildInfoCard(
+                icon: Icons.apps,
+                title: 'みまもり中のアプリ',
+                value: '$_enabledAppsCount個',
+                color: Colors.green,
+              ),
+              const SizedBox(height: 32),
+
+              // その他
+              _buildSectionHeader('その他'),
+              const SizedBox(height: 16),
+              _buildSettingCard(
+                icon: Icons.privacy_tip_outlined,
+                title: 'プライバシーポリシー',
+                subtitle: 'データの取り扱いについて',
+                color: Colors.deepPurple,
+                onTap: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('プライバシーポリシーは準備中です'),
+                      duration: Duration(seconds: 1),
+                    ),
+                  );
+                },
+              ),
+              const SizedBox(height: 12),
+              _buildSettingCard(
+                icon: Icons.help_outline,
+                title: '使い方ガイド',
+                subtitle: 'アプリの使い方を確認',
+                color: Colors.orange,
+                onTap: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('使い方ガイドは準備中です'),
+                      duration: Duration(seconds: 1),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(String title) {
+    return Text(
+      title,
+      style: const TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+
+  Widget _buildSettingCard({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required Color color,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 10,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                color: color.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(
+                icon,
+                color: color,
+                size: 24,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    subtitle,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right,
+              color: Colors.grey[400],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoCard({
+    required IconData icon,
+    required String title,
+    required String value,
+    required Color color,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(
+              icon,
+              color: color,
+              size: 24,
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              title,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/ui/shortcut_guide_screen.dart
+++ b/frontend/lib/ui/shortcut_guide_screen.dart
@@ -1,0 +1,357 @@
+import 'package:flutter/material.dart';
+import '../models/monitored_app.dart';
+
+class ShortcutGuideScreen extends StatelessWidget {
+  final MonitoredApp app;
+
+  const ShortcutGuideScreen({
+    super.key,
+    required this.app,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        title: const Text(
+          'ショートカット設定',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        backgroundColor: Colors.deepPurple,
+        foregroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(20.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // アプリ情報カード
+                    Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(20.0),
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          colors: [app.color.withOpacity(0.8), app.color],
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                        ),
+                        borderRadius: BorderRadius.circular(20),
+                        boxShadow: [
+                          BoxShadow(
+                            color: app.color.withOpacity(0.3),
+                            blurRadius: 15,
+                            offset: const Offset(0, 8),
+                          ),
+                        ],
+                      ),
+                      child: Row(
+                        children: [
+                          Container(
+                            width: 60,
+                            height: 60,
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(15),
+                            ),
+                            child: Icon(
+                              app.icon,
+                              color: app.color,
+                              size: 35,
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Text(
+                                  '追加完了',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: Colors.white70,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  app.displayName,
+                                  style: const TextStyle(
+                                    fontSize: 22,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const Icon(
+                            Icons.check_circle,
+                            color: Colors.white,
+                            size: 32,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+
+                    // 説明
+                    const Text(
+                      'ショートカットを設定しよう',
+                      style: TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      '${app.displayName}の起動を記録するには、iPhoneの「ショートカット」アプリで設定が必要です。',
+                      style: TextStyle(
+                        fontSize: 15,
+                        color: Colors.grey[700],
+                        height: 1.5,
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+
+                    // 設定手順
+                    const Text(
+                      '設定手順',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+
+                    _buildStep(
+                      number: '1',
+                      title: 'ショートカットアプリを開く',
+                      description: 'iPhoneの「ショートカット」アプリをタップして開きます',
+                      icon: Icons.apps,
+                      color: Colors.blue,
+                    ),
+                    const SizedBox(height: 16),
+
+                    _buildStep(
+                      number: '2',
+                      title: 'オートメーションを作成',
+                      description: '画面下部の「オートメーション」タブ → 右上の「+」ボタンをタップ',
+                      icon: Icons.add_circle_outline,
+                      color: Colors.green,
+                    ),
+                    const SizedBox(height: 16),
+
+                    _buildStep(
+                      number: '3',
+                      title: 'アプリを選択',
+                      description: '「アプリ」を選択 → "${app.displayName}"を選択 → 「開いた」をチェック',
+                      icon: Icons.touch_app,
+                      color: Colors.orange,
+                    ),
+                    const SizedBox(height: 16),
+
+                    _buildStep(
+                      number: '4',
+                      title: 'アクションを追加',
+                      description: '「次へ」→ アクションを追加 → 「URL」を検索 → 「URLを開く」を追加',
+                      icon: Icons.link,
+                      color: Colors.purple,
+                    ),
+                    const SizedBox(height: 16),
+
+                    _buildStep(
+                      number: '5',
+                      title: 'URLを設定',
+                      description: 'URLに以下を入力:\nmiivvy://log?app=${app.id}',
+                      icon: Icons.edit,
+                      color: Colors.red,
+                      isLast: true,
+                    ),
+                    const SizedBox(height: 24),
+
+                    // 注意事項
+                    Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: Colors.amber.shade50,
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: Colors.amber.shade200),
+                      ),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Icon(Icons.lightbulb_outline, color: Colors.amber.shade700),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'ヒント',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.bold,
+                                    color: Colors.amber.shade900,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  '設定後、「実行時に尋ねない」をオンにすると、アプリ起動時に自動で記録されます。',
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    color: Colors.amber.shade900,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // 完了ボタン
+            Container(
+              padding: const EdgeInsets.all(20.0),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.1),
+                    blurRadius: 10,
+                    offset: const Offset(0, -4),
+                  ),
+                ],
+              ),
+              child: SafeArea(
+                top: false,
+                child: SizedBox(
+                  width: double.infinity,
+                  height: 54,
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.deepPurple,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      elevation: 0,
+                    ),
+                    child: const Text(
+                      '完了',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStep({
+    required String number,
+    required String title,
+    required String description,
+    required IconData icon,
+    required Color color,
+    bool isLast = false,
+  }) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Column(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: color,
+                shape: BoxShape.circle,
+              ),
+              child: Center(
+                child: Text(
+                  number,
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+            if (!isLast)
+              Container(
+                width: 2,
+                height: 40,
+                color: Colors.grey.shade300,
+                margin: const EdgeInsets.symmetric(vertical: 4),
+              ),
+          ],
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.05),
+                  blurRadius: 8,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(icon, color: color, size: 20),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: const TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  description,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Colors.grey[700],
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/ui/splash_screen.dart
+++ b/frontend/lib/ui/splash_screen.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'dashboard_screen.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _fadeAnimation;
+  late Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // アニメーションコントローラーを初期化
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1500),
+      vsync: this,
+    );
+
+    // フェードインアニメーション
+    _fadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.0, 0.6, curve: Curves.easeIn),
+    ));
+
+    // スケールアニメーション
+    _scaleAnimation = Tween<double>(
+      begin: 0.8,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.0, 0.6, curve: Curves.easeOut),
+    ));
+
+    // アニメーション開始
+    _controller.forward();
+
+    // 2秒後にダッシュボード画面へ遷移
+    Future.delayed(const Duration(seconds: 2), () {
+      if (mounted) {
+        Navigator.of(context).pushReplacement(
+          PageRouteBuilder(
+            pageBuilder: (context, animation, secondaryAnimation) => const DashboardScreen(),
+            transitionsBuilder: (context, animation, secondaryAnimation, child) {
+              return FadeTransition(
+                opacity: animation,
+                child: child,
+              );
+            },
+            transitionDuration: const Duration(milliseconds: 500),
+          ),
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.deepPurple,
+      body: Center(
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (context, child) {
+            return FadeTransition(
+              opacity: _fadeAnimation,
+              child: ScaleTransition(
+                scale: _scaleAnimation,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    // ロゴアイコン
+                    Container(
+                      width: 120,
+                      height: 120,
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        shape: BoxShape.circle,
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withOpacity(0.1),
+                            blurRadius: 20,
+                            offset: const Offset(0, 10),
+                          ),
+                        ],
+                      ),
+                      child: const Icon(
+                        Icons.visibility,
+                        size: 60,
+                        color: Colors.deepPurple,
+                      ),
+                    ),
+                    const SizedBox(height: 32),
+
+                    // アプリ名
+                    const Text(
+                      'Miivvy',
+                      style: TextStyle(
+                        fontSize: 48,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                        letterSpacing: 2,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+
+                    // タグライン
+                    const Text(
+                      '信頼は、ちゃんと記録できる。',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Colors.white70,
+                        letterSpacing: 1,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -72,6 +88,11 @@ packages:
     version: "5.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -139,6 +160,102 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "34266009473bf71d748912da4bf62d439185226c03e01e2d9687bc65bbfcb713"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.15"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "1c33a907142607c40a7542768ec9badfd16293bac51da3a4482623d15845f88b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,6 +325,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.35.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -21,6 +21,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
+  # Shared Preferences for storing app settings
+  shared_preferences: ^2.3.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
- Replace "監視" with "みまもり" throughout the app for a friendlier tone
- Change "監視停止中" to "休憩中" (hedgehog resting theme)
- Implement empty initial state (no default apps)
- Add app selection screen with 6 available apps (LINE, Instagram, X, Facebook, TikTok, Discord)
- Add permission confirmation dialog before adding apps
- Add shortcut setup guide screen with 5-step instructions
- Implement swipe-to-delete functionality for removing apps
- Add empty state UI with "Add App" button
- Update app status labels to "みまもりON/OFF" for clarity
- Fix .gitignore to allow Flutter lib/ directory

🦔 Generated with [Claude Code](https://claude.com/claude-code)