### PR TITLE
feat: Add Cloud Run deployment configuration with uv support

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,47 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+
+# UV
+.uv/
+
+# Tests
+tests/
+*.test.py
+pytest_cache/
+.pytest_cache/
+
+# Environment
+.env
+.env.local
+*.log
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Git
+.git/
+.gitignore
+
+# macOS
+.DS_Store
+
+# Development
+README.md
+*.md
+
+# Firebase credentials (will be set via environment variables)
+serviceAccountKey.json
+*credentials*.json

--- a/backend/.gcloudignore
+++ b/backend/.gcloudignore
@@ -1,0 +1,46 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+
+#!include:.gitignore
+
+# Python pycache:
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# UV specific
+.uv/
+
+# Tests
+tests/
+*.test.py
+pytest_cache/
+
+# Development
+.env
+.env.local
+*.log
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Documentation
+README.md
+*.md
+
+# Git
+.git/
+.gitignore
+
+# macOS
+.DS_Store

--- a/backend/DEPLOYMENT.md
+++ b/backend/DEPLOYMENT.md
@@ -1,0 +1,175 @@
+# Miivvy Backend Deployment Guide
+
+このガイドでは、Miivvy BackendをGoogle Cloud Runにデプロイする手順を説明します。
+
+## 前提条件
+
+- Google Cloud アカウント
+- gcloud CLI がインストール済み
+- Firebase プロジェクトが作成済み
+- uvがインストール済み（ローカル開発用）
+
+## デプロイ方法
+
+### 1. Google Cloud プロジェクトの設定
+
+```bash
+# プロジェクトIDを設定
+export PROJECT_ID="your-project-id"
+
+# gcloud CLIでプロジェクトを選択
+gcloud config set project $PROJECT_ID
+
+# Cloud Run APIを有効化
+gcloud services enable run.googleapis.com
+gcloud services enable cloudbuild.googleapis.com
+```
+
+### 2. Firebase 認証情報の設定
+
+Cloud Runでは、環境変数経由でFirebase認証情報を渡すか、サービスアカウントを使用します。
+
+**オプション A: サービスアカウントを使用（推奨）**
+
+```bash
+# Firebaseプロジェクトと同じプロジェクトなら、デフォルトのサービスアカウントが使用されます
+# 追加設定不要
+```
+
+**オプション B: 認証情報JSONを環境変数で渡す**
+
+```bash
+# Firebase コンソールから serviceAccountKey.json をダウンロード
+# base64エンコードして環境変数に設定
+export FIREBASE_CREDENTIALS=$(cat serviceAccountKey.json | base64)
+```
+
+### 3. Cloud Run にデプロイ
+
+```bash
+cd backend
+
+# Cloud Runにデプロイ（uvを使用したDockerビルド）
+gcloud run deploy miivvy-api \
+  --source . \
+  --platform managed \
+  --region asia-northeast1 \
+  --allow-unauthenticated \
+  --set-env-vars "FLASK_ENV=production" \
+  --set-env-vars "SECRET_KEY=your-production-secret-key" \
+  --set-env-vars "OPENAI_API_KEY=your-openai-api-key" \
+  --memory 512Mi \
+  --cpu 1 \
+  --timeout 60 \
+  --max-instances 10
+```
+
+### 4. デプロイ確認
+
+デプロイが完了すると、URLが表示されます：
+
+```
+Service URL: https://miivvy-api-xxxxx-an.a.run.app
+```
+
+ヘルスチェック：
+
+```bash
+curl https://miivvy-api-xxxxx-an.a.run.app/
+```
+
+期待されるレスポンス：
+
+```json
+{
+  "status": "healthy",
+  "message": "Miivvy Backend API with Firebase is running",
+  "version": "0.2.0",
+  "features": ["firebase", "firestore", "openai"]
+}
+```
+
+### 5. Webhook URLの確認
+
+ショートカット生成時に使用するWebhook URL：
+
+```
+https://miivvy-api-xxxxx-an.a.run.app/api/webhook
+```
+
+このURLをフロントエンドアプリやショートカット生成APIで使用します。
+
+## ローカルでのDockerテスト
+
+デプロイ前にローカルでDockerイメージをテストできます：
+
+```bash
+cd backend
+
+# Dockerイメージをビルド
+docker build -t miivvy-backend .
+
+# コンテナを起動
+docker run -p 8080:8080 \
+  -e FLASK_ENV=development \
+  -e SECRET_KEY=dev-secret \
+  -e OPENAI_API_KEY=your-key \
+  miivvy-backend
+
+# 別ターミナルでテスト
+curl http://localhost:8080/
+```
+
+## 環境変数
+
+本番環境で設定すべき環境変数：
+
+| 環境変数 | 説明 | 必須 |
+|---------|------|------|
+| `FLASK_ENV` | `production` に設定 | ✅ |
+| `SECRET_KEY` | Flaskのシークレットキー（ランダム文字列） | ✅ |
+| `OPENAI_API_KEY` | OpenAI APIキー | ✅ |
+| `FIREBASE_CREDENTIALS` | Firebase認証情報JSON（base64） | ⚠️ |
+| `PORT` | ポート番号（Cloud Runが自動設定） | ❌ |
+
+⚠️ = サービスアカウントを使用しない場合のみ必須
+
+## トラブルシューティング
+
+### Firebaseの初期化エラー
+
+```
+DefaultCredentialsError: Your default credentials were not found
+```
+
+**解決方法：**
+- Cloud Runのサービスアカウントに「Firebase Admin SDK Administrator Service Agent」ロールを付与
+- または、`FIREBASE_CREDENTIALS`環境変数を設定
+
+### メモリ不足エラー
+
+**解決方法：**
+- `--memory 1Gi` にメモリを増やす
+
+### タイムアウトエラー
+
+**解決方法：**
+- `--timeout 300` にタイムアウトを延長
+
+## 継続的デプロイ（CI/CD）
+
+GitHub Actionsを使った自動デプロイは、`.github/workflows/deploy.yml` に設定予定です。
+
+## コスト見積もり
+
+Cloud Runの料金（東京リージョン）：
+- リクエスト: 100万リクエストまで無料
+- CPU時間: 月180,000 vCPU秒まで無料
+- メモリ: 月360,000 GiB秒まで無料
+
+通常のMVPフェーズでは無料枠内で運用可能です。
+
+## 関連ドキュメント
+
+- [API仕様書](./API_SHORTCUTS.md)
+- [テストガイド](./tests/api/README.md)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,24 @@
+# Use official Python runtime as base image
+FROM python:3.12-slim
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files
+COPY pyproject.toml ./
+
+# Install dependencies using uv
+RUN uv pip install --system --no-cache -r pyproject.toml
+
+# Copy application code
+COPY . .
+
+# Set environment variables
+ENV PORT=8080
+ENV PYTHONUNBUFFERED=1
+
+# Run the application using gunicorn
+CMD exec uv run gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,14 @@
+"""
+Cloud Run entry point for Miivvy Backend
+This file is used when deploying to Google Cloud Run
+"""
+from app import create_app
+
+# Create Flask app instance for gunicorn
+app = create_app()
+
+if __name__ == '__main__':
+    # For local testing
+    import os
+    port = int(os.getenv('PORT', 8080))
+    app.run(host='0.0.0.0', port=port, debug=False)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "openai>=1.0.0",
     "firebase-admin>=6.5.0",
+    "gunicorn>=22.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -612,6 +612,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "23.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -871,6 +883,7 @@ dependencies = [
     { name = "firebase-admin" },
     { name = "flask" },
     { name = "flask-cors" },
+    { name = "gunicorn" },
     { name = "openai" },
     { name = "python-dotenv" },
 ]
@@ -891,6 +904,7 @@ requires-dist = [
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "flask-cors", specifier = ">=4.0.0" },
+    { name = "gunicorn", specifier = ">=22.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },


### PR DESCRIPTION
Implemented Google Cloud Run deployment setup using Docker and uv for dependency management. This enables deploying the Miivvy backend API to a production environment with a publicly accessible webhook URL.

Features:
- Dockerfile with uv integration for dependency management
- main.py entry point for gunicorn WSGI server
- .dockerignore and .gcloudignore for optimized builds
- Comprehensive deployment documentation (DEPLOYMENT.md)

Technical Details:
- Uses official Python 3.12 slim image
- Installs dependencies via uv from pyproject.toml
- Runs with gunicorn (1 worker, 8 threads)
- Configured for Cloud Run environment (PORT=8080)
- Added gunicorn>=22.0.0 to project dependencies

Testing:
- ✅ Local gunicorn test successful (port 8080)
- ✅ Health check endpoint working
- ✅ Shortcut generation API working
- ✅ Generated .shortcut files verified (5.3KB XML plist)

Deployment:
- Ready for Cloud Run deployment
- Supports environment variables for configuration
- No requirements.txt needed - uses uv exclusively

🤖 Generated with [Claude Code](https://claude.com/claude-code)