### PR TITLE
chore: Add .gitignore to backend directory

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,34 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# UV
+.uv/
+
+# Environment
+.env
+.env.local
+*.log
+
+# IDE
+.vscode/
+.idea/
+
+# Tests
+tests/
+*.test.py
+
+# macOS
+.DS_Store
+
+# Firebase credentials
+serviceAccountKey.json
+*credentials*.json


### PR DESCRIPTION
Added .gitignore file to backend directory for proper file exclusion during Cloud Run deployment and local development.

Excludes:
- Python cache files (__pycache__, *.pyc)
- Virtual environments (.venv, venv, env)
- UV cache (.uv)
- Environment files (.env, .env.local)
- IDE files (.vscode, .idea)
- Test files (tests/, *.test.py)
- macOS files (.DS_Store)
- Firebase credentials (serviceAccountKey.json)

This file was required for successful gcloud deployment and should have been included from the beginning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)